### PR TITLE
Build uwsgi from c1296ae99557de87994a7d817d075bb911fbc7a535e2e0bafe04…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
-  sha256: 88ab9867d8973d8ae84719cf233b7dafc54326fcaec89683c3f9f77c002cdff9
+#  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
+  url: https://github.com/unbit/uwsgi/archive/ffced3256e6de7e841e4ca038620437f3c8042c0.tar.gz
+  sha256: c1296ae99557de87994a7d817d075bb911fbc7a535e2e0bafe04250559fdad69
 
 build:
-  number: 3
+  number: 4
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
…250559fdad69

Attempt to fix Python 3.10 compatibility: https://github.com/unbit/uwsgi/pull/2363

There is currently no tagged release upstream in uwsgi. Is there any process for proposing a provisional/custom/etc release originating here?



<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
